### PR TITLE
Make Backend::Local run compatible with Netssh - allows use of local by ...

### DIFF
--- a/lib/sshkit/backends/local.rb
+++ b/lib/sshkit/backends/local.rb
@@ -11,7 +11,7 @@ module SSHKit
       end
 
       def run
-        instance_exec(&@block)
+        instance_exec(host, &@block)
       end
 
       def test(*args)


### PR DESCRIPTION
Following https://github.com/capistrano/sshkit/pull/163 so they could merge it :)
